### PR TITLE
Fix texture reference issues (#90, #91)

### DIFF
--- a/creator_camp/resource_packs/creator_camp/entity/campghost.entity.json
+++ b/creator_camp/resource_packs/creator_camp/entity/campghost.entity.json
@@ -10,7 +10,7 @@
       },
       "textures": {
         "default": "textures/entity/campghost/campghost",
-        "charged": "textures/entity/campghost/campghost_armor"
+        "charged": "textures/entity/campghost/creeper_armor"
       },
       "geometry": {
         "default": "geometry.campghost.v1.8",

--- a/creator_camp/resource_packs/creator_camp/textures/item_texture.json
+++ b/creator_camp/resource_packs/creator_camp/textures/item_texture.json
@@ -1,5 +1,6 @@
 {
   "resource_pack_name": "Creator Camp 2025 - Item Demo",
+  "texture_name": "atlas.items",
   "texture_data": {
     "ccid:leaf_bag": {
       "textures": "textures/items/leaf_bag"


### PR DESCRIPTION
## Summary
This PR fixes two texture-related issues in the creator_camp sample pack:

- **Issue #91**: Fixed incorrect campghost armor texture reference
  - Changed `textures/entity/campghost/campghost_armor` to `textures/entity/campghost/creeper_armor`
  - The texture file that actually exists is `creeper_armor.png`

- **Issue #90**: Added missing `texture_name` field to item_texture.json
  - Added `"texture_name": "atlas.items"` which was causing errors for the leaf bag item

## Files Changed
- `creator_camp/resource_packs/creator_camp/entity/campghost.entity.json`
- `creator_camp/resource_packs/creator_camp/textures/item_texture.json`

## Testing
Both files now reference textures that actually exist in the resource pack.