### PR TITLE
docs: add deferred_lighting_starter to README samples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This project contains samples that further extend the [Minecraft: Bedrock Editio
  * [Features Samples](https://github.com/microsoft/minecraft-samples/blob/main/FeaturesSamples.mcaddon) - A sample pack that can be used as a tutorial on how features and feature rules work.
  * [Custom Items](custom_items/README.md) - Build and create custom items for Minecraft
  * [Custom Sounds](custom_sounds/README.md) - Demonstrates techniques for adding custom sounds to Minecraft.
- * [Debug Tools](debug_tools/README.md) - Contains a set of simple debug tools for adding in-game and editor watches.
+  * [Debug Tools](debug_tools/README.md) - Contains a set of simple debug tools for adding in-game and editor watches.
+ * [Deferred Lighting Starter](deferred_lighting_starter/README.md) - A starter pack for exploring deferred lighting and PBR rendering features in Bedrock Edition.
  * [Jigsaws](jigsaws/README.md) - This sample is the behavior pack used in the [Jigsaw Block Tutorial](https://learn.microsoft.com/minecraft/creator/documents/structures/jigsawtutorial)
  * [Minecraft Live 2022 Add-Ons](mclive2022_addon) - Behavior Pack and Resource Pack that accompany the [Minecraft Live 2022 Creator Recap](https://learn.microsoft.com/minecraft/creator/documents/minecraftlive2022creatorrecap)
  * [NPC Dialog Sample](npc_dialogue_sample/README.md) - See the [NPC Dialogue](https://learn.microsoft.com/minecraft/creator/documents/NPCDialogue) documentation for the full walkthrough adding custom dialogue for an NPC


### PR DESCRIPTION
### Description
This PR adds the missing `deferred_lighting_starter` sample to the **Current Samples** list in the main `README.md`. 

### Context
While exploring the repository, I noticed that the `deferred_lighting_starter` folder is present in the root directory but was left out of the main documentation index.

### Changes
- Added `[Deferred Lighting Starter](deferred_lighting_starter/README.md)` to the list.
- Placed it in between **debug_tools** and **jigsaws**